### PR TITLE
Add clojure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update > /dev/null 2>&1 \
 
 RUN apt install -y \
     clisp \
+    clojure1.6 \
     dmd-bin \
     erlang \
     gauche \


### PR DESCRIPTION
### clojureのバージョン確認について
```
$ clojure
Clojure1.6.0
use=>
```
とバージョンは表示されますが、そのまま対話形式へと移行してしまいます。
バージョン確認のみのオプションがないみたいです。