### PR TITLE
Remove php7 command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ RUN bash /tmp/show_versions.sh \
     "python3 -V | head -n 1" \
     "perl -v | sed -n 2P" \
     "php -v | head -n 1" \
-    "php7 --version | head -n 1" \
     "swipl --version | head -n 1" \
     "ruby -v | head -n 1" \
     "rustc --version | head -n 1" \


### PR DESCRIPTION
phpコマンドでphp7になってるので、php7コマンドを削除（そもそもコマンド存在してなかった）
シェルのevalでバージョンが取得できないものも直したかったけどよくわかりませんでした。